### PR TITLE
Cleanup and upgrade arrow, datafusion deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,4 +24,5 @@ debug-assertions = true
 overflow-checks = true
 
 [workspace.dependencies]
-datafusion = {version="44.0.0", features=["pyarrow"]}
+arrow = { version = "54.1.0", features = ["ffi", "pyarrow"] }
+datafusion = { version = "45.0.0" }

--- a/generate-vectors/src/graph.rs
+++ b/generate-vectors/src/graph.rs
@@ -34,6 +34,7 @@ impl FullGraph {
             .expect("Missing id field")
     }
 
+    #[allow(unused)]
     pub fn record_count(&self) -> usize {
         self.id_graph().values.len()
     }

--- a/vectorlink-hnsw-python/Cargo.toml
+++ b/vectorlink-hnsw-python/Cargo.toml
@@ -5,13 +5,14 @@ edition = "2021"
 description = "Python bindings for vectorlink-hnsw"
 
 [dependencies]
+arrow = { workspace = true }
 datafusion = { workspace = true }
 paste = "1.0.15"
 tokio-stream = "0.1.17"
 vectorlink-hnsw = { version = "0.1.0", path = "../vectorlink-hnsw" }
 
 [dependencies.pyo3]
-version = "0.22.4"
+version = "0.23.3"
 # "abi3-py38" tells pyo3 / maturin to build using the stable ABI with Python >= 3.8
 features = ["abi3-py38", "experimental-async"]
 

--- a/vectorlink-hnsw-python/src/lib.rs
+++ b/vectorlink-hnsw-python/src/lib.rs
@@ -4,10 +4,10 @@ use ::vectorlink_hnsw::{
     comparator::CosineDistance1536, hnsw, index, layer, params, serialize,
     util, vectors,
 };
+use arrow::pyarrow::PyArrowType;
 use datafusion::arrow::{
     array::{Array, ArrayData},
     ffi_stream::{ArrowArrayStreamReader, FFI_ArrowArrayStream},
-    pyarrow::PyArrowType,
 };
 use pyo3::{
     create_exception,
@@ -33,8 +33,7 @@ fn vectorlink_hnsw(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<BuildParams>()?;
     m.add_class::<OptimizationParams>()?;
     m.add_class::<SearchParams>()?;
-    // m.add("SerializeError", m.py().get_type::<SerializeError>())?;  // For 0.23.x
-    m.add("SerializeError", m.py().get_type_bound::<SerializeError>())?;
+    m.add("SerializeError", m.py().get_type::<SerializeError>())?;
     Ok(())
 }
 

--- a/vectorlink-hnsw/Cargo.toml
+++ b/vectorlink-hnsw/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+arrow = { workspace = true }
 bytemuck = "1.20.0"
 datafusion = { workspace = true }
 enum_dispatch = "0.3.13"

--- a/vectorlink-hnsw/src/serialize.rs
+++ b/vectorlink-hnsw/src/serialize.rs
@@ -6,6 +6,7 @@ use std::{
     sync::Arc,
 };
 
+use arrow::ffi_stream::ArrowArrayStreamReader;
 use datafusion::arrow::{
     array::{
         Array, FixedSizeListArray, RecordBatch, RecordBatchReader, UInt32Array,
@@ -13,7 +14,6 @@ use datafusion::arrow::{
     buffer::{Buffer, ScalarBuffer},
     datatypes::{DataType, Field, Schema},
     error::ArrowError,
-    ffi_stream::ArrowArrayStreamReader,
 };
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};


### PR DESCRIPTION
- Upgrade the arrow and datafusion deps
- Declare arrow as workspace dep
- Use arrow's pyarrow feature and associated use-stmts instead of datafusion's
- Upgrade pyo3 dep version to 0.23.3, and Exception registration along with it